### PR TITLE
Changed GPT Model + Regex Requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask~=2.3.2
 openai~=0.27.8
 requests~=2.31.0
+regex~=2023.6.3

--- a/server.py
+++ b/server.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     config: Config = Config(
         api_key_file="openai_key.txt",
         model_description_file="model_description.txt",
-        model="davinci"
+        model="gpt-3.5-turbo"
     )
 
     openai.api_key = config.api_key


### PR DESCRIPTION
- Changed the GPT Model from `'davinci'` to `'gpt-3.5-turbo'` to avoid error.
- Added Regex Version `2023.6.3` to requirements to avoid missing regex.